### PR TITLE
support contextvars

### DIFF
--- a/greenletio/core.py
+++ b/greenletio/core.py
@@ -151,7 +151,7 @@ def await_(coro_or_fn):
         if not bridge.running and not bridge.starting:
             bridge.start()
 
-        return bridge.bridge_greenlet.switch(coro_or_fn)
+        return bridge.bridge_greenlet.switch(asyncio.create_task(coro_or_fn))
     else:
         # assume decorator usage
         @functools.wraps(coro_or_fn)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -173,6 +173,7 @@ class TestCore(unittest.TestCase):
         @async_
         def foo():
             assert var.get() == 1
+            await_(bar())
             var.set(3)
             assert var.get() == 3
 


### PR DESCRIPTION
This patch allows propagating variables in the calling context into greenlets.
