### PR TITLE
Improve portability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3']
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/greenletio/green/threading.py
+++ b/src/greenletio/green/threading.py
@@ -222,7 +222,7 @@ class Thread(_original_threading_.Thread):
         if kwargs is None:
             kwargs = {}
         self._target = target
-        self._name = str(name or _original_threading_._newname())
+        self._name = str(name or _original_threading_._newname("GreenletioThread-%d"))
         self._args = args
         self._kwargs = kwargs
         self._daemonic = False


### PR DESCRIPTION
Hi! I suggest few changes. If you accept it i will write tests for each feat.

I was try to replace fastapi "run_in_threadpool" by "run_in_greenletio". I'm failed with ThreadPoolExecutors which used in my tests, cause they don't patched correctly. And this changes i was made due implement this "feature" in our project.

Our stack is fastapi + django + psycopg2. And we write sync handlers and async handler only for huge-load API methods.
In few places (fastapi.Depends) we use `asgiref.sync_to_async`, this is why i add options to `async_` decorator.

Patching `loop.run_until_complete` is from `fastapi` test infrastructure and their sync TestClient.

Changelog:

~~- **feat**: now GreenletBridge allow use loop.run_until_complete to run async code from sync~~

  ~~loop.run_until_complete - is common "gateway" from sync to async world. Now it's just replaced by `await_` which is "common" for greenletio~~

- **feat**: now async_ return coroutine function which can be checked by asyncio.iscoroutinefunction; add copy_context and copyback_context params to make call similar to common coroutine

  Example how it used in popular libs:
https://github.com/tiangolo/fastapi/blob/d666ccb62216e45ca78643b52c235ba0d2c53986/fastapi/routing.py#L183

  Possible workaround to keep decorator sync:
https://github.com/django/asgiref/blob/03571587bf0f61ddff77f1f6fe3593439cb92f48/asgiref/sync.py#L36

- **feat**: add support python >= 3.10