### PR TITLE
Clean up event loop handling

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ include_package_data = True
 package_dir =
     = src
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 install_requires =
     greenlet
 

--- a/src/greenletio/green/ssl.py
+++ b/src/greenletio/green/ssl.py
@@ -2,8 +2,9 @@ import os
 import sys
 from greenletio.io import wait_to_read, wait_to_write
 from greenletio.patcher import copy_globals
-from ssl import SSLWantReadError, SSLWantWriteError, PROTOCOL_TLS_SERVER, PROTOCOL_TLS_CLIENT, Purpose, \
-    CERT_NONE, CERT_REQUIRED, _ASN1Object
+from ssl import SSLWantReadError, SSLWantWriteError, PROTOCOL_TLS, \
+    PROTOCOL_TLS_SERVER, PROTOCOL_TLS_CLIENT, Purpose, \
+    CERT_NONE, _ASN1Object
 import ssl as _original_ssl_
 
 copy_globals(_original_ssl_, globals())

--- a/src/greenletio/green/ssl.py
+++ b/src/greenletio/green/ssl.py
@@ -2,7 +2,7 @@ import os
 import sys
 from greenletio.io import wait_to_read, wait_to_write
 from greenletio.patcher import copy_globals
-from ssl import SSLWantReadError, SSLWantWriteError, PROTOCOL_TLS, Purpose, \
+from ssl import SSLWantReadError, SSLWantWriteError, PROTOCOL_TLS_SERVER, PROTOCOL_TLS_CLIENT, Purpose, \
     CERT_NONE, CERT_REQUIRED, _ASN1Object
 import ssl as _original_ssl_
 
@@ -121,12 +121,10 @@ def create_default_context(purpose=Purpose.SERVER_AUTH, *, cafile=None,
     # SSLContext sets OP_NO_SSLv2, OP_NO_SSLv3, OP_NO_COMPRESSION,
     # OP_CIPHER_SERVER_PREFERENCE, OP_SINGLE_DH_USE and OP_SINGLE_ECDH_USE
     # by default.
-    context = SSLContext(PROTOCOL_TLS)
-
-    if purpose == Purpose.SERVER_AUTH:
-        # verify certs and host name in client mode
-        context.verify_mode = CERT_REQUIRED
-        context.check_hostname = True
+    if purpose ==Purpose.SERVER_AUTH:
+        context = SSLContext(PROTOCOL_TLS_CLIENT)
+    else:
+        context = SSLContext(PROTOCOL_TLS_SERVER)
 
     if cafile or capath or cadata:
         context.load_verify_locations(cafile, capath, cadata)

--- a/src/greenletio/green/threading.py
+++ b/src/greenletio/green/threading.py
@@ -2,7 +2,7 @@ import asyncio
 import collections
 import weakref
 import greenlet
-from greenletio.core import await_, async_
+from greenletio.core import await_, async_, get_loop
 from greenletio.patcher import copy_globals
 import threading as _original_threading_
 
@@ -109,7 +109,7 @@ class Condition:
 
         self.release()
         try:
-            fut = asyncio.get_event_loop().create_future()
+            fut = get_loop().create_future()
             self._waiters.append(fut)
             try:
                 if timeout is None:
@@ -243,7 +243,7 @@ class Thread(_original_threading_.Thread):
         async def bootstrap():
             await async_(self._bootstrap)()
 
-        self.task = asyncio.ensure_future(bootstrap())
+        self.task = asyncio.ensure_future(bootstrap(), loop=get_loop())
         self._started.set()
 
     def _set_ident(self):

--- a/src/greenletio/io.py
+++ b/src/greenletio/io.py
@@ -1,19 +1,19 @@
 import asyncio
-from greenletio.core import await_
+from greenletio.core import await_, get_loop
 
 
 def wait_to_read(fd):
     event = asyncio.Event()
-    asyncio.get_event_loop().add_reader(fd, event.set)
+    get_loop().add_reader(fd, event.set)
     await_(event.wait())
-    asyncio.get_event_loop().remove_reader(fd)
+    get_loop().remove_reader(fd)
 
 
 def wait_to_write(fd):
     event = asyncio.Event()
-    asyncio.get_event_loop().add_writer(fd, event.set)
+    get_loop().add_writer(fd, event.set)
     await_(event.wait())
-    asyncio.get_event_loop().remove_writer(fd)
+    get_loop().remove_writer(fd)
 
 
 def wait_many(read_list, write_list, timeout=None):
@@ -32,15 +32,15 @@ def wait_many(read_list, write_list, timeout=None):
         event.set()
 
     for fd in read_list:
-        asyncio.get_event_loop().add_reader(fd, _reader_callback, fd)
+        get_loop().add_reader(fd, _reader_callback, fd)
     for fd in write_list:
-        asyncio.get_event_loop().add_writer(fd, _writer_callback, fd)
+        get_loop().add_writer(fd, _writer_callback, fd)
     try:
         await_(asyncio.wait_for(event.wait(), timeout))
     except asyncio.TimeoutError:  # pragma: no cover
         pass
     for fd in read_list:
-        asyncio.get_event_loop().remove_reader(fd)
+        get_loop().remove_reader(fd)
     for fd in write_list:
-        asyncio.get_event_loop().remove_writer(fd)
+        get_loop().remove_writer(fd)
     return readers, writers

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -3,9 +3,7 @@ import sys
 import unittest
 from greenletio.core import bridge, async_
 from greenletio.green import socket, selectors, time
-
-if not hasattr(asyncio, 'create_task'):
-    asyncio.create_task = asyncio.ensure_future
+from .util import run_coro
 
 
 class TestSelect(unittest.TestCase):
@@ -70,8 +68,5 @@ class TestSelect(unittest.TestCase):
             while var is None:
                 await asyncio.sleep(0)
 
-        if sys.platform == 'win32':
-            loop = asyncio.SelectorEventLoop()
-            asyncio.set_event_loop(loop)
-        asyncio.get_event_loop().run_until_complete(main())
+        run_coro(main())
         assert var == b'HELLO'

--- a/tests/test_socket.py
+++ b/tests/test_socket.py
@@ -4,8 +4,7 @@ import unittest
 from greenletio.core import bridge, async_
 from greenletio.green import socket
 
-if not hasattr(asyncio, 'create_task'):
-    asyncio.create_task = asyncio.ensure_future
+from .util import run_coro
 
 
 class TestSocket(unittest.TestCase):
@@ -46,10 +45,7 @@ class TestSocket(unittest.TestCase):
             while var is None:
                 await asyncio.sleep(0)
 
-        if sys.platform == 'win32':
-            loop = asyncio.SelectorEventLoop()
-            asyncio.set_event_loop(loop)
-        asyncio.get_event_loop().run_until_complete(main())
+        run_coro(main())
         assert var == b'HELLO'
 
     def test_sendto_recvfrom(self):
@@ -79,8 +75,5 @@ class TestSocket(unittest.TestCase):
             while var is None:
                 await asyncio.sleep(0)
 
-        if sys.platform == 'win32':
-            loop = asyncio.SelectorEventLoop()
-            asyncio.set_event_loop(loop)
-        asyncio.get_event_loop().run_until_complete(main())
+        run_coro(main())
         assert var == b'HELLO'

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 from greenletio.core import bridge, async_
 from greenletio.green import socket, ssl
+from .util import run_coro
 
 # Tests in this module use server and client certificates
 #
@@ -62,10 +63,5 @@ class TestSSL(unittest.TestCase):
             while var is None:
                 await asyncio.sleep(0)
 
-        if sys.platform == 'win32':
-            loop = asyncio.SelectorEventLoop()
-        else:
-            loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        loop.run_until_complete(main())
+        run_coro(main())
         assert var == b'HELLO'

--- a/tests/test_ssl.py
+++ b/tests/test_ssl.py
@@ -14,9 +14,6 @@ from greenletio.green import socket, ssl
 # openssl req -x509 -newkey rsa:4096 -keyout client.key -out client.crt
 # -days 365 -nodes -subj "/CN=example.com"
 
-if not hasattr(asyncio, 'create_task'):
-    asyncio.create_task = asyncio.ensure_future
-
 
 class TestSSL(unittest.TestCase):
     def setUp(self):
@@ -67,6 +64,8 @@ class TestSSL(unittest.TestCase):
 
         if sys.platform == 'win32':
             loop = asyncio.SelectorEventLoop()
-            asyncio.set_event_loop(loop)
-        asyncio.get_event_loop().run_until_complete(main())
+        else:
+            loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(main())
         assert var == b'HELLO'

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,11 @@
+import asyncio
+import sys
+
+
+def run_coro(coro):
+    if sys.platform == 'win32':
+        loop = asyncio.SelectorEventLoop()
+    else:
+        loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop.run_until_complete(coro)


### PR DESCRIPTION
Thanks for this library!

I was trying it out and noticed it was raising `DeprecationWarnings` from the changing behavior of [`asyncio.get_event_loop`](https://docs.python.org/3/library/asyncio-eventloop.html?highlight=get_event_loop#asyncio.get_event_loop).

This PR cleans up the handling of event loops as well as the deprecation of [`ssl.PROTOCOL_TLS`](https://docs.python.org/3/library/ssl.html?highlight=sslcontext#ssl.PROTOCOL_TLS).  It also handles the `RuntimeWarning` raised in `test_bad_await_with_external_loop`, to get a clean `pytest` run with no warnings.

Note that Python 3.6 support was explicitly dropped, so we can rely on `asyncio.get_running_loop` and `asyncio.create_task`.